### PR TITLE
GH-16: Add ability to unlock user with an email address.

### DIFF
--- a/src/js/server/utils.js
+++ b/src/js/server/utils.js
@@ -173,7 +173,7 @@ fluid.express.user.utils.verifyPassword = function (userRecord, password) {
  * Otherwise a standard error Object is returned.
  *
  * @param {fluid.express.user.utils} that - Utils component.
- * @param {String} username - Username to use for record lookup.
+ * @param {String} username - Username (or email address) to use for record lookup.
  * @param {String} password - Clear text password to validate record with.
  * @return {fluid.promise} - Promise resolving with a `userData` record if the password is correct, otherwise
  * rejecting with an `isError` Object.
@@ -182,7 +182,7 @@ fluid.express.user.utils.unlockUser = function (that, username, password) {
     var promiseTogo = fluid.promise();
     that.byUsernameOrEmailReader.get({username: username}).then(
         function (body) {
-            if (body.username) {
+            if (body.username || body.email) {
                 var user = body;
                 var encodedPassword = fluid.express.user.password.encode(password, user.salt, user.iterations, user.keyLength, user.digest);
                 if (encodedPassword === user.derived_key) {

--- a/tests/js/server/utils-tests.js
+++ b/tests/js/server/utils-tests.js
@@ -60,12 +60,24 @@ fluid.defaults("fluid.tests.express.user.utils.caseHolder", {
                     ]
                 },
                 {
-                    name: "Testing unlocking a user with correct credentials.",
+                    name: "Testing unlocking a user with a correct username and password.",
                     type: "test",
                     sequence: [
                         {
                             task: "fluid.tests.express.user.utils.unlockPromise",
                             args: ["{fluid.express.user.utils}", "existing", "password"],
+                            resolve: "jqUnit.assertEquals",
+                            resolveArgs: ["Check verified username", "existing", "{arguments}.0.username"]
+                        }
+                    ]
+                },
+                {
+                    name: "Testing unlocking a user with a correct email address and password.",
+                    type: "test",
+                    sequence: [
+                        {
+                            task: "fluid.tests.express.user.utils.unlockPromise",
+                            args: ["{fluid.express.user.utils}", "existing@localhost", "password"],
                             resolve: "jqUnit.assertEquals",
                             resolveArgs: ["Check verified username", "existing", "{arguments}.0.username"]
                         }


### PR DESCRIPTION
@jobara pointed out a key assumption in the utils that prevents logging in using only a username.  This pull should address that.